### PR TITLE
Correção na escrita de linhas.

### DIFF
--- a/lib/geradores/geradorDePdf.js
+++ b/lib/geradores/geradorDePdf.js
@@ -121,7 +121,7 @@ module.exports = function(danfe, args, callback) {
         x1 = margemEsquerda + args.ajusteX + x1;
         x2 = margemDireita + args.ajusteX + x2;
 
-        return pdf.moveTo(x1, y).lineTo(x2, y).dash(false).stroke(cor || args.corDoLayout);
+        return pdf.moveTo(x1, y).lineTo(x2, y).stroke();
     }
 
     function linhaHorizontalTracejada(x1, x2, y) {
@@ -129,7 +129,7 @@ module.exports = function(danfe, args, callback) {
         x1 = margemEsquerda + args.ajusteX + x1;
         x2 = margemDireita + args.ajusteX + x2;
 
-        return pdf.moveTo(x1, y).lineTo(x2, y).dash(3, { space: 5 }).stroke(args.corDoLayout);
+        return pdf.moveTo(x1, y).lineTo(x2, y).dash(3, { space: 5 }).stroke();
     }
 
     function linhaVertical(y1, y2, x, cor) {
@@ -137,7 +137,7 @@ module.exports = function(danfe, args, callback) {
         y1 = margemTopo + args.ajusteY + y1;
         y2 = margemTopo + args.ajusteY + y2;
 
-        return pdf.moveTo(x, y1).lineTo(x, y2).dash(false).stroke(cor || args.corDoLayout);
+        return pdf.moveTo(x, y1).lineTo(x, y2).stroke();
     }
 
     function secao(string, x, y, largura, alinhamento, tamanho) {


### PR DESCRIPTION
Na geração das linhas o método "stroke()" recebe parâmetros, por alguma razão o Adobe não estava intendendo-as, também removi o método "dash()" de linhas onde ele não era necessário (linhas não tracejadas).

Como estava:
return pdf.moveTo(x1, y).lineTo(x2, y).dash(false).stroke(cor || args.corDoLayout);
Como ficou:
return pdf.moveTo(x1, y).lineTo(x2, y).stroke();

Após alteração não tive mais problemas.
